### PR TITLE
Implement UI tests execution into GitHub action workflow

### DIFF
--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           java-version: 1.8
 
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v2.3.4
 
       - name: Load Gradle cached
         uses: actions/cache@v2
@@ -24,6 +24,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+          upload-chunk-size: 4000000
 
       # Run Detekt and Archive Detekt reports
       - name: Run Detekt on CoroutineTemplate

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -24,7 +24,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-          upload-chunk-size: 4000000
+          upload-chunk-size: 20000000
 
       # Run Detekt and Archive Detekt reports
       - name: Run Detekt on CoroutineTemplate

--- a/.github/workflows/ui_test.yml
+++ b/.github/workflows/ui_test.yml
@@ -6,10 +6,6 @@ jobs:
   ui_test:
     name: Execute UI tests
     runs-on: self-hosted
-    strategy:
-      matrix:
-        api-level: [ 30 ]
-        target: [ google_apis ]
     steps:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -28,38 +24,14 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-          upload-chunk-size: 4000000
-
-      # Set up AVD snapshot caching
-      - name: Load AVD cached
-        id: avd-cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
-          upload-chunk-size: 4000000
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          force-avd-creation: false
-          working-directory: ./RxJavaTemplate
-          script: echo "Generated AVD snapshot for caching."
+          upload-chunk-size: 20000000
 
       # Run UI tests & Archive reports
       - name: Run UI tests on RxJavaTemplate
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          force-avd-creation: false
+          api-level: 30
+          target: google_apis
           working-directory: ./RxJavaTemplate
           script: ./gradlew connectedCheck
 

--- a/.github/workflows/ui_test.yml
+++ b/.github/workflows/ui_test.yml
@@ -1,7 +1,11 @@
 name: UI Test
 
 # TODO : update when to trigger this workflow as you wish
-on: push
+on:
+  # Run UI test every time we release
+  push:
+    branches:
+      - main
 jobs:
   ui_test:
     name: Execute UI tests

--- a/.github/workflows/ui_test.yml
+++ b/.github/workflows/ui_test.yml
@@ -1,0 +1,71 @@
+name: UI Test
+
+# TODO : update when to trigger this workflow as you wish
+on: push
+jobs:
+  ui_test:
+    name: Execute UI tests
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        api-level: [ 30 ]
+        target: [ google_apis ]
+    steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - uses: actions/checkout@v2.3.4
+
+      - name: Load Gradle cached
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+          upload-chunk-size: 4000000
+
+      # Set up AVD snapshot caching
+      - name: Load AVD cached
+        id: avd-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+          upload-chunk-size: 4000000
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          force-avd-creation: false
+          working-directory: ./RxJavaTemplate
+          script: echo "Generated AVD snapshot for caching."
+
+      # Run UI tests & Archive reports
+      - name: Run UI tests on RxJavaTemplate
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          force-avd-creation: false
+          working-directory: ./RxJavaTemplate
+          script: ./gradlew connectedCheck
+
+      - name: Archive UI test reports on RxJavaTemplate
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ui-test-report-rxjava
+          path: RxJavaTemplate/app/build/reports/androidTests/connected/


### PR DESCRIPTION
## What happened 👀

Implement UI tests execution into GitHub action workflow
 
## Insight 📝

Create workflow responsible for executing UI tests
- Use `reactivecircus/android-emulator-runner` to run the Android emulator.
- Update `actions/checkout` version.
- We need to define `upload-chunk-size: 20000000` to resolve caching problem as the default value is too big for a local machine (MacBook Pro) and will cause a caching process to be failed, see more detail [here](https://github.com/actions/cache/issues/259).

## Proof Of Work 📹

All workflows are executed correctly.
