### PR TITLE
Bring back AVD caching

### DIFF
--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -24,7 +24,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-          upload-chunk-size: 20000000
 
       # Run Detekt and Archive Detekt reports
       - name: Run Detekt on CoroutineTemplate

--- a/.github/workflows/ui_test.yml
+++ b/.github/workflows/ui_test.yml
@@ -1,15 +1,19 @@
 name: UI Test
 
-# TODO : update when to trigger this workflow as you wish
 on:
-  # Run UI test every time we release
+  # Trigger the workflow on push action in develop branch
+  # So it will trigger when the PR of the feature branch was merged.
   push:
     branches:
-      - main
+      - develop
 jobs:
   ui_test:
     name: Execute UI tests
     runs-on: self-hosted
+    strategy:
+      matrix:
+        api-level: [ 30 ]
+        target: [ google_apis ]
     steps:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -28,14 +32,36 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-          upload-chunk-size: 20000000
+
+      # Set up AVD snapshot caching
+      - name: Load AVD cached
+        id: avd-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          force-avd-creation: false
+          working-directory: ./RxJavaTemplate
+          script: echo "Generated AVD snapshot for caching."
 
       # Run UI tests & Archive reports
       - name: Run UI tests on RxJavaTemplate
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          target: google_apis
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          force-avd-creation: false
           working-directory: ./RxJavaTemplate
           script: ./gradlew connectedCheck
 


### PR DESCRIPTION
## What happened 👀

As we are now using a new runner (MacStadium's Mac mini) which is significantly more powerful in terms of performance, we no longer have an issue with retrieving cache speed. Therefore, we can bring back the AVD caching feature as it will help decrease the launching time of the Android emulator.
 
## Insight 📝

- Bring back the AVD caching feature.
- Reset `upload-chunk-size` to the default value as it doesn't need to be reduced anymore.
 
## Proof Of Work 📹

All workflows running as expected.
