### PR TITLE
[chore] Add `README` to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The repository for proof of concept of [Custom Runner for Github Actions (Androi
 
 ### Giving the ability to run on a self-hosted runner to workflows
 
-Define the following key to all the jobs that we target to run on a self-hosted runner.
+Define the following key to all the jobs that we target to run on a self-hosted runner:
 
 ```
 runs-on: self-hosted

--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
-# Android Templates: RxJava
-- Our optimized Android templates used in our android projects
+# GitHub Actions Runner for Android
 
-### Setup
-- Clone the project
-- Checkout our main development branch `kotlin`
-- Run the project with Android Studio
+The repository for proof of concept of [Custom Runner for Github Actions (Android) initiative](https://www.notion.so/nimblehq/Custom-Runner-for-Github-Actions-Android-bb4c0b6310184e44afe9b3bea0989a57?d=72eb950e-33be-482b-8e17-40c92023073d)
 
-### Linter and static code analysis
+## Setup custom runner
 
-1. Check Style:
+### Prerequisites
 
-```
-$ ./gradlew checkStyle
-```
+- Machine running macOS from [MacStadium](https://www.macstadium.com/) or a physical one
+- Android Studio installation is recommended as it will help to install all the required Java, Android
+  SDK, also the AVD which needed for running UI test
 
-Report is located at: `./app/build/reports/checkstyle/`
+### Add custom (self-hosted) runner
 
-2. Detekt
+1. Open the **Settings** menu of the repository. Go to **Actions** -> **Runners** -> click on the **Add runner** button
+2. Make sure the Operating System dropdown shows **macOS** as a selected item, then run all of the below commands in your machine in order. Specify configurations when prompted.
+3. (Optional) In the directory where the runner was installed, run `./svc.sh install`. This program is for help checking the status of the runner.
+4. In the directory where the runner was installed, run `./run.sh` to open the runner to listening for the upcoming jobs.
 
-```
-$ ./gradlew detekt
-```
+### Giving the ability to run on a self-hosted runner to workflow
 
-Report is located at: `./build/reports/detekt.html`
+Define `runs-on: self-hosted` to all the jobs we want to be run on a self-hosted runner.
+
+### Known issues
+
+- One runner can only execute one job at a time. To run multiple jobs or workflows simultaneously, we might need to consider adding a new runner in the same or different machine.
+- There is an issue related to `actions/cache` in a low-performance machine as the default `upload-chunk-size` value is too big for such a machine. Consider reducing this value when facing such an issue.
+- If there's an error related to being incapable of finding the Android SDK. We might need to specify the Android SDK path into `ANDROID_SDK_ROOT` environment variable, for example: `export ANDROID_SDK_ROOT=/Users/username/Library/Android/sdk`.
+- In a low-performance machine, Creating an AVD from scratch every time running the Android emulator might be a better solution in terms of execution time as the speed for retrieving cache is low in such a machine.
+
+## About
+
+![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
+
+This project is maintained and funded by Nimble.

--- a/README.md
+++ b/README.md
@@ -2,31 +2,58 @@
 
 The repository for proof of concept of [Custom Runner for Github Actions (Android) initiative](https://www.notion.so/nimblehq/Custom-Runner-for-Github-Actions-Android-bb4c0b6310184e44afe9b3bea0989a57?d=72eb950e-33be-482b-8e17-40c92023073d)
 
-## Setup custom runner
+## Setup self-hosted runner
 
 ### Prerequisites
 
-- Machine running macOS from [MacStadium](https://www.macstadium.com/) or a physical one
-- Android Studio installation is recommended as it will help to install all the required Java, Android
-  SDK, also the AVD which needed for running UI test
+- Machine running macOS from [MacStadium](https://www.macstadium.com/) or a local one.
+- Android Studio installation is recommended as it will help to install other required programs such as Java, Android SDK, and AVD (needed for running the UI test).
 
-### Add custom (self-hosted) runner
+### Add a self-hosted runner to GitHub repository
 
-1. Open the **Settings** menu of the repository. Go to **Actions** -> **Runners** -> click on the **Add runner** button
-2. Make sure the Operating System dropdown shows **macOS** as a selected item, then run all of the below commands in your machine in order. Specify configurations when prompted.
-3. (Optional) In the directory where the runner was installed, run `./svc.sh install`. This program is for help checking the status of the runner.
-4. In the directory where the runner was installed, run `./run.sh` to open the runner to listening for the upcoming jobs.
+1. Open the **Settings** menu of the repository. Go to **Actions** -> **Runners** -> click on the **Add runner** button.
+2. Make sure the Operating System dropdown shows macOS as a selected OS, then run all of the listed commands in your machine respectively and specify configurations when prompted.
+3. (Optional) In the directory where the runner was installed, run the following command to install `svc`, which is a program that can help to check and manage the status of the runner.
 
-### Giving the ability to run on a self-hosted runner to workflow
+   ```
+   ./svc.sh install
+   ```
 
-Define `runs-on: self-hosted` to all the jobs we want to be run on a self-hosted runner.
+4. In the directory where the runner was installed, run the following command to launch and inform the runner to listening for the upcoming jobs.
+
+   ```
+   ./run.sh
+   ```
+
+### Giving the ability to run on a self-hosted runner to workflows
+
+Define the following key to all the jobs that we target to run on a self-hosted runner.
+
+```
+...
+runs-on: self-hosted
+...
+```
+
+📓 Note that we can use the label feature to specify which workflows will run only on which machines. Assigning labels can be done when configuring a runner using the command line or with the UI via the GitHub repository Settings page. To specify labels to a workflow, for example, define the following key to all the jobs that we target to run on self-hosted runners with a mini-1 label.
+
+```
+...
+runs-on: [self-hosted, mini-1]
+...
+```
+
+to all the jobs that we target to run on a self-hosted runner on machines with a **mini-1** label.
 
 ### Known issues
 
-- One runner can only execute one job at a time. To run multiple jobs or workflows simultaneously, we might need to consider adding a new runner in the same or different machine.
-- There is an issue related to `actions/cache` in a low-performance machine as the default `upload-chunk-size` value is too big for such a machine. Consider reducing this value when facing such an issue.
-- If there's an error related to being incapable of finding the Android SDK. We might need to specify the Android SDK path into `ANDROID_SDK_ROOT` environment variable, for example: `export ANDROID_SDK_ROOT=/Users/username/Library/Android/sdk`.
-- In a low-performance machine, Creating an AVD from scratch every time running the Android emulator might be a better solution in terms of execution time as the speed for retrieving cache is low in such a machine.
+- One runner can only execute one job at a time. To run multiple jobs or workflows simultaneously, we need to consider adding a new runner in the same or different machine.
+- There is an issue related to `actions/cache` in a low-performance machine since the default `upload-chunk-size` value is too big. In this case, we should consider reducing this value to the point that such an issue is gone.
+- In case there's an error related to being incapable of finding the Android SDK. We can resolve it by specifying the Android SDK path into the `ANDROID_SDK_ROOT` environment variable, for example:
+
+  ```
+  export ANDROID_SDK_ROOT=/Users/username/Library/Android/sdk
+  ```
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,89 @@
-# GitHub Actions Runner for Android
+<p align="center">
+  <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-320.png" />
+</p>
+
+---
+
+A collection of templates:
+
+* **[CoroutineTemplate](https://github.com/nimblehq/android-templates/tree/kotlin/CoroutineTemplate)**
+* **[RxJavaTemplate](https://github.com/nimblehq/android-templates/tree/kotlin/RxJavaTemplate)**
+
+## Setup
+
+1. Clone or download this repository to your local machine, then extract and open the folder
+2. Run `newproject.sh` script to create a new project with the following inputs:
+
+```
+  -h, --help                         Display this usage message and exit
+  -t, --template [TEMPLATE]          Select template: "rx" - RxJavaTemplate or "crt" - CoroutineTemplate (i.e. rx)
+  -p, --package-name [PACKAGE_NAME]  New package name (i.e. com.example.package)
+  -n, --app-name [APP_NAME]          New app name (i.e. MyApp, "My App")
+```
+
+Example:
+- Init a new project with `RxJavaTemplate`
+  `./newproject.sh -t rx -p co.myproject.example -n "My Project"`
+
+- Init a new project with `CoroutineTemplate`
+  `./newproject.sh -t crt -p co.myproject.example -n "My Project"`
+
+3. Update `android_version_code` and `android_version_name`
+- `RxJavaTemplate/build.gradle`
+- `CoroutineTemplate/build.gradle`
+
+---
+
+## GitHub Actions Runner for Android
 
 The repository for proof of concept of [Custom Runner for Github Actions (Android) initiative](https://www.notion.so/nimblehq/Custom-Runner-for-Github-Actions-Android-bb4c0b6310184e44afe9b3bea0989a57?d=72eb950e-33be-482b-8e17-40c92023073d)
 
-## Setup self-hosted runner
+### Setup self-hosted runner
 
-### Prerequisites
+#### Prerequisites
 
 - Machine running macOS from [MacStadium](https://www.macstadium.com/) or a local one.
 - Android Studio installation is recommended as it will help to install other required programs such as Java, Android SDK, and AVD (needed for running the UI test).
 
-### Add a self-hosted runner to GitHub repository
+#### Add a self-hosted runner to GitHub repository
 
 1. Open the **Settings** menu of the repository. Go to **Actions** -> **Runners** -> click on the **Add runner** button.
-2. Make sure the Operating System dropdown shows macOS as a selected OS, then run all of the listed commands in your machine respectively and specify configurations when prompted.
+2. Make sure the Operating System dropdown shows **macOS** as a selected OS, then run all of the listed commands in your machine respectively and specify configurations when prompted.
 3. (Optional) In the directory where the runner was installed, run the following command to install `svc`, which is a program that can help to check and manage the status of the runner.
 
-   ```
-   ./svc.sh install
-   ```
+```
+./svc.sh install
+```
 
 4. In the directory where the runner was installed, run the following command to launch and inform the runner to listening for the upcoming jobs.
 
-   ```
-   ./run.sh
-   ```
+```
+./run.sh
+```
 
-### Giving the ability to run on a self-hosted runner to workflows
+#### Giving the ability to run on a self-hosted runner to workflows
 
 Define the following key to all the jobs that we target to run on a self-hosted runner.
 
 ```
-...
 runs-on: self-hosted
-...
 ```
 
-📓 Note that we can use the label feature to specify which workflows will run only on which machines. Assigning labels can be done when configuring a runner using the command line or with the UI via the GitHub repository Settings page. To specify labels to a workflow, for example, define the following key to all the jobs that we target to run on self-hosted runners with a mini-1 label.
+> 📓 Note that we can use the label feature to specify which workflows will run only on which machines. Assigning labels can be done when configuring a runner using the command line or with the UI via the GitHub repository Settings page. To specify labels to a workflow, for example, define the following key to all the jobs that we target to run on self-hosted runners with a **mini-1** label.
+>
+> ```
+> runs-on: [self-hosted, mini-1]
+> ```
 
-```
-...
-runs-on: [self-hosted, mini-1]
-...
-```
-
-to all the jobs that we target to run on a self-hosted runner on machines with a **mini-1** label.
-
-### Known issues
+#### Known issues
 
 - One runner can only execute one job at a time. To run multiple jobs or workflows simultaneously, we need to consider adding a new runner in the same or different machine.
 - There is an issue related to `actions/cache` in a low-performance machine since the default `upload-chunk-size` value is too big. In this case, we should consider reducing this value to the point that such an issue is gone.
 - In case there's an error related to being incapable of finding the Android SDK. We can resolve it by specifying the Android SDK path into the `ANDROID_SDK_ROOT` environment variable, for example:
-
-  ```
-  export ANDROID_SDK_ROOT=/Users/username/Library/Android/sdk
-  ```
+  
+```
+export ANDROID_SDK_ROOT=/Users/username/Library/Android/sdk
+```
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -1,67 +1,35 @@
-<p align="center">
-  <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-320.png" />
-</p>
+# GitHub Actions Runner for Android
 
----
+The repository for proof of concept of [Custom Runner for Github Actions (Android) initiative][initiative]
 
-A collection of templates:
+[initiative]: https://www.notion.so/nimblehq/Custom-Runner-for-Github-Actions-Android-bb4c0b6310184e44afe9b3bea0989a57?d=72eb950e-33be-482b-8e17-40c92023073d
 
-* **[CoroutineTemplate](https://github.com/nimblehq/android-templates/tree/kotlin/CoroutineTemplate)**
-* **[RxJavaTemplate](https://github.com/nimblehq/android-templates/tree/kotlin/RxJavaTemplate)**
+## Setup self-hosted runner
 
-## Setup
+### Prerequisites
 
-1. Clone or download this repository to your local machine, then extract and open the folder
-2. Run `newproject.sh` script to create a new project with the following inputs:
+- Machine running macOS from [MacStadium] or a local one.
+- Android Studio installation is recommended to facilitate the installation of other required programs such as Java, Android SDK, and AVD (needed for running the UI test).
 
-```
-  -h, --help                         Display this usage message and exit
-  -t, --template [TEMPLATE]          Select template: "rx" - RxJavaTemplate or "crt" - CoroutineTemplate (i.e. rx)
-  -p, --package-name [PACKAGE_NAME]  New package name (i.e. com.example.package)
-  -n, --app-name [APP_NAME]          New app name (i.e. MyApp, "My App")
-```
+[MacStadium]: https://www.macstadium.com/
 
-Example:
-- Init a new project with `RxJavaTemplate`
-  `./newproject.sh -t rx -p co.myproject.example -n "My Project"`
-
-- Init a new project with `CoroutineTemplate`
-  `./newproject.sh -t crt -p co.myproject.example -n "My Project"`
-
-3. Update `android_version_code` and `android_version_name`
-- `RxJavaTemplate/build.gradle`
-- `CoroutineTemplate/build.gradle`
-
----
-
-## GitHub Actions Runner for Android
-
-The repository for proof of concept of [Custom Runner for Github Actions (Android) initiative](https://www.notion.so/nimblehq/Custom-Runner-for-Github-Actions-Android-bb4c0b6310184e44afe9b3bea0989a57?d=72eb950e-33be-482b-8e17-40c92023073d)
-
-### Setup self-hosted runner
-
-#### Prerequisites
-
-- Machine running macOS from [MacStadium](https://www.macstadium.com/) or a local one.
-- Android Studio installation is recommended as it will help to install other required programs such as Java, Android SDK, and AVD (needed for running the UI test).
-
-#### Add a self-hosted runner to GitHub repository
+### Add a self-hosted runner to GitHub repository
 
 1. Open the **Settings** menu of the repository. Go to **Actions** -> **Runners** -> click on the **Add runner** button.
-2. Make sure the Operating System dropdown shows **macOS** as a selected OS, then run all of the listed commands in your machine respectively and specify configurations when prompted.
-3. (Optional) In the directory where the runner was installed, run the following command to install `svc`, which is a program that can help to check and manage the status of the runner.
+2. Make sure the Operating System dropdown shows **macOS** as a selected OS, then run all of the listed commands from the instruction in your machine respectively and specify configurations when prompted.
+3. (Optional) In the directory where the runner was installed, run the following command to install **svc**, which is a program that can help to check and manage the status of the runner.
 
-```
-./svc.sh install
-```
+   ```
+   ./svc.sh install
+   ```
 
 4. In the directory where the runner was installed, run the following command to launch and inform the runner to listening for the upcoming jobs.
 
-```
-./run.sh
-```
+   ```
+   ./run.sh
+   ```
 
-#### Giving the ability to run on a self-hosted runner to workflows
+### Giving the ability to run on a self-hosted runner to workflows
 
 Define the following key to all the jobs that we target to run on a self-hosted runner.
 
@@ -75,18 +43,31 @@ runs-on: self-hosted
 > runs-on: [self-hosted, mini-1]
 > ```
 
-#### Known issues
+### Known issues
 
 - One runner can only execute one job at a time. To run multiple jobs or workflows simultaneously, we need to consider adding a new runner in the same or different machine.
 - There is an issue related to `actions/cache` in a low-performance machine since the default `upload-chunk-size` value is too big. In this case, we should consider reducing this value to the point that such an issue is gone.
 - In case there's an error related to being incapable of finding the Android SDK. We can resolve it by specifying the Android SDK path into the `ANDROID_SDK_ROOT` environment variable, for example:
-  
-```
-export ANDROID_SDK_ROOT=/Users/username/Library/Android/sdk
-```
+
+  ```
+  export ANDROID_SDK_ROOT=/Users/username/Library/Android/sdk
+  ```
+
+## License
+
+This project is Copyright (c) 2014 and onwards. It is free software,
+and may be redistributed under the terms specified in the [LICENSE] file.
+
+[LICENSE]: /LICENSE
 
 ## About
 
 ![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
 
 This project is maintained and funded by Nimble.
+
+We love open source and do our part in sharing our work with the community!
+See [our other projects][community] or [hire our team][hire] to help build your product.
+
+[community]: https://github.com/nimblehq
+[hire]: https://nimblehq.co/


### PR DESCRIPTION
## What happened 👀

As there's quite complicate to follow the process of setting up the self-hosted runner for GitHub actions that have been done on this repository, we should add the `README` guide for the benefit in terms of documenting.
 
## Insight 📝

Add `README` which contained a guide for setting up a self-hosted runner for GitHub actions
 
## Proof Of Work 📹

A new `README` file has been added.
