### PR TITLE
[POC] Separate unit test, UI test, and deploy step for performance testing

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run_tests_and_deploy_production:
     name: Run tests and deploy production
-    runs-on: self-hosted
+    runs-on: [ self-hosted, ui-test ]
     strategy:
       matrix:
         api-level: [ 30 ]

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run_tests_and_deploy_staging:
     name: Run tests and deploy staging
-    runs-on: self-hosted
+    runs-on: [ self-hosted, ui-test ]
     strategy:
       matrix:
         api-level: [ 30 ]

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -4,15 +4,78 @@ on:
   # Only trigger this workflow on push action in develop branch
   push:
     branches:
-      - develop
+      - poc/separate-unit-test-from-ui-test
 jobs:
-  run_tests_and_deploy_staging:
-    name: Run tests and deploy staging
+  run_ui_tests:
+    name: Run ui tests
     runs-on: [ self-hosted, ui-test ]
     strategy:
       matrix:
         api-level: [ 30 ]
         target: [ google_apis ]
+    steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - uses: actions/checkout@v2.3.4
+
+      - name: Load cached Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+          # Currently set to default value
+          upload-chunk-size: 33554432
+
+      # Set up AVD snapshot caching
+      - name: Load cached AVD
+        id: avd-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+          # Currently set to default value
+          upload-chunk-size: 33554432
+
+      - name: Create AVD & generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          force-avd-creation: false
+          script: echo "Generated AVD snapshot for caching."
+
+      # Run UI tests & archive reports
+      - name: Run UI tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          force-avd-creation: false
+          script: ./gradlew connectedCheck
+
+      - name: Archive UI test reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ui-test-reports
+          path: app/build/reports/androidTests/connected/
+
+  run_unit_tests:
+    name: Run unit tests and deploy staging
+    runs-on: self-hosted
     steps:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -57,44 +120,30 @@ jobs:
             app/build/reports/jacoco/jacocoTestReport/
             data/build/reports/jacoco/jacocoTestReport/
 
-      # Set up AVD snapshot caching
-      - name: Load cached AVD
-        id: avd-cache
+  deploy_staging:
+    needs: [ run_ui_tests, run_unit_tests ]
+    name: Deploy staging
+    runs-on: self-hosted
+    steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - uses: actions/checkout@v2.3.4
+
+      - name: Load cached Gradle
         uses: actions/cache@v2
         with:
           path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
           # Currently set to default value
           upload-chunk-size: 33554432
-
-      - name: Create AVD & generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          force-avd-creation: false
-          script: echo "Generated AVD snapshot for caching."
-
-      # Run UI tests & archive reports
-      - name: Run UI tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          force-avd-creation: false
-          script: ./gradlew connectedCheck
-
-      - name: Archive UI test reports
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: ui-test-reports
-          path: app/build/reports/androidTests/connected/
 
       # Build staging debug artifact
       - name: Build artifact


### PR DESCRIPTION
## What happened 👀

Assume that separating the Unit test, UI test, and deployment will reduce execution time.
 
## Insight 📝

- Separate the jobs for Unit test, UI test and staging deployment.
- Assign `ui-test` label for UI testing. The rest assign the default `self-hosted`
- Push this branch to run all jobs

 
## Proof Of Work 📹

It takes around 7 mins to complete all jobs.
