### PR TITLE
[POC] Don't separate the jobs for Unit test, UI test, and deployment step

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run_tests_and_deploy_production:
     name: Run tests and deploy production
-    runs-on: self-hosted
+    runs-on: [ self-hosted, ui-test ]
     strategy:
       matrix:
         api-level: [ 30 ]

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -4,7 +4,7 @@ on:
   # Only trigger this workflow on push action in develop branch
   push:
     branches:
-      - develop
+      - poc/not-separate
 jobs:
   run_tests_and_deploy_staging:
     name: Run tests and deploy staging

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run_tests_and_deploy_staging:
     name: Run tests and deploy staging
-    runs-on: self-hosted
+    runs-on: [ self-hosted, ui-test ]
     strategy:
       matrix:
         api-level: [ 30 ]


### PR DESCRIPTION
## What happened 👀

Assume that separating the Unit test, UI test, and deployment will reduce execution time.
 
## Insight 📝

- Didn't separate the jobs for Unit test, UI test, and staging deployment.
- Assign `ui-test` label to all steps
- Push this branch to run all jobs
 
## Proof Of Work 📹

It takes around 4 - 5 mins to complete all jobs.
